### PR TITLE
Handle serial exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+## Interactive hex serial port console

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+serial-tool (1.2.1) stable; urgency=medium
+
+  * Handle serial exceptions
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 27 May 2024 15:10:00 +0400
+
 serial-tool (1.2.0) stable; urgency=medium
 
   * python3 port

--- a/serial_tool.py
+++ b/serial_tool.py
@@ -120,19 +120,23 @@ def main():
         print(termcolor.colored("ERROR:", "red"), "incorrect stop bits setting %d" % args.stop_bits)
         return 1
 
-    # configure the serial connections (the parameters differs on the device you are connecting to)
-    ser = serial.Serial(
-        port=args.port,
-        baudrate=args.baud,
-        parity=args.parity,
-        stopbits=args.stop_bits,
-        bytesize=args.data_bits,
-    )
+    try:
+        # configure the serial connections (the parameters differs on the device you are connecting to)
+        ser = serial.Serial(
+            port=args.port,
+            baudrate=args.baud,
+            parity=args.parity,
+            stopbits=args.stop_bits,
+            bytesize=args.data_bits,
+        )
 
-    if args.batch_mode:
-        return do_batch_mode(args, ser)
-    else:
-        return do_interactive_mode(args, ser)
+        if args.batch_mode:
+            return do_batch_mode(args, ser)
+        else:
+            return do_interactive_mode(args, ser)
+    except serial.serialutil.SerialException as e:
+        print(termcolor.colored("ERROR: " + str(e), "red"), file=sys.stderr)
+        return 1
 
 
 def do_batch_mode(args, ser):


### PR DESCRIPTION
Before:
```sh
$ serial_tool /dev/ttRS485-2
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/serial/serialposix.py", line 322, in open
    self.fd = os.open(self.portstr, os.O_RDWR | os.O_NOCTTY | os.O_NONBLOCK)
FileNotFoundError: [Errno 2] No such file or directory: '/dev/ttRS485-2'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/bin/serial_tool", line 224, in <module>
    rc = main()
  File "/usr/bin/serial_tool", line 124, in main
    ser = serial.Serial(
  File "/usr/lib/python3/dist-packages/serial/serialutil.py", line 244, in __init__
    self.open()
  File "/usr/lib/python3/dist-packages/serial/serialposix.py", line 325, in open
    raise SerialException(msg.errno, "could not open port {}: {}".format(self._port, msg))
serial.serialutil.SerialException: [Errno 2] could not open port /dev/ttRS485-2: [Errno 2] No such file or directory: '/dev/ttRS485-2'
```
After:
```sh
$ serial_tool /dev/ttRS485-2
ERROR: [Errno 2] could not open port /dev/ttRS485-2: [Errno 2] No such file or directory: '/dev/ttRS485-2'
```