### PR TITLE
Fix launch error

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+serial-tool (1.2.4) stable; urgency=medium
+
+  * Fix launch error
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 20 Jun 2025 16:23:00 +0400
+
 serial-tool (1.2.3) stable; urgency=medium
 
   * Enable angry pylint. No functional changes

--- a/serial_tool.py
+++ b/serial_tool.py
@@ -83,7 +83,7 @@ def main():
         "--stop-bits",
         dest="stop_bits",
         type=float,
-        help=f"set number of stop bits, one of [{', '.join(serial.Serial.STOPBITS)}]",
+        help=f"set number of stop bits, one of [{', '.join(str(x) for x in serial.Serial.STOPBITS)}]",
         default=1,
     )
 

--- a/serial_tool.py
+++ b/serial_tool.py
@@ -83,7 +83,7 @@ def main():
         "--stop-bits",
         dest="stop_bits",
         type=float,
-        help=f"set number of stop bits, one of [{', '.join(str(x) for x in serial.Serial.STOPBITS)}]",
+        help=f"set number of stop bits, one of [{', '.join(map(str, serial.Serial.STOPBITS))}]",
         default=1,
     )
 


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Сломали запуск:
```
serial_tool -h
Traceback (most recent call last):
  File "/usr/bin/serial_tool", line 217, in <module>
    rc = main()
  File "/usr/bin/serial_tool", line 86, in main
    help=f"set number of stop bits, one of [{', '.join(serial.Serial.STOPBITS)}]",
TypeError: sequence item 0: expected str instance, int found
```

___________________________________
**Что поменялось для пользователей:**
запускается вновь

___________________________________
**Как проверял/а:**
на контроллере проверил

